### PR TITLE
Update README.md: Fixed the invalid syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ contract CryptoVault {
     */
 
     function sweepToken(IERC20 token) public {
-        require(token != underlying, "Can't transfer underlying token");
+        require(token != underlying, "Cant transfer underlying token");
         token.transfer(sweptTokensRecipient, token.balanceOf(address(this)));
     }
 }


### PR DESCRIPTION
Don't know why but that `'` was messing up with the code and it doesn't look good

Deleting it gave us a clear look

Try previewing the .md file for a better clarification